### PR TITLE
Fix Sudoku checker function name

### DIFF
--- a/check_sudoku.py
+++ b/check_sudoku.py
@@ -1,4 +1,4 @@
-def check_suduku(p):
+def check_sudoku(p):
 	n = len(p)
 	digit = 1
 	while digit <= n:


### PR DESCRIPTION
## Summary
- rename `check_suduku` to `check_sudoku`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6840d7e67a288326a1e791d74147c79c